### PR TITLE
feat: Add error handling via ErrorModule

### DIFF
--- a/src/modules/app.module.ts
+++ b/src/modules/app.module.ts
@@ -4,6 +4,7 @@ import {
     AuthenticationClient,
     AuthModule,
     CoreModule,
+    ErrorModule,
     LoginService,
     TokenValidator,
     UserDatabaseService as UserDatabaseServiceBase,
@@ -68,6 +69,11 @@ import { DatabaseModule } from './database.module'
                 },
             ],
             exports: [GoogleSheetsService, GoogleLoginService],
+        }),
+        ErrorModule.forRoot({
+            errorCardOptions: {
+                helpCenterLink: Sheets.HELP_CENTER_LINK,
+            },
         }),
     ],
     providers: [

--- a/src/services/actions.service.spec.ts
+++ b/src/services/actions.service.spec.ts
@@ -5,7 +5,8 @@ import { Test } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
 import MockDate from 'mockdate'
 
-import { buildTask, buildUser } from '../../test/fixtures'
+import { buildUser } from '../../test/fixtures'
+import { setupGetTasks, setupGetToken, setupGetUser } from '../../test/setups'
 import { CardActions as SheetCardActions } from '../constants/card-actions'
 import { User } from '../entities/user.entity'
 import * as csvHelpers from '../utils/csv-helpers'
@@ -131,6 +132,9 @@ describe('ActionsService', () => {
                         content: 'My Project',
                         contentPlain: 'My Project',
                     } as ContextMenuData,
+                    inputs: {
+                        'Input.completed': 'true',
+                    },
                 },
                 extensionType: 'context-menu',
                 maximumDoistCardVersion: 0.5,
@@ -293,21 +297,4 @@ describe('ActionsService', () => {
             })
         })
     })
-
-    function setupGetUser(user: User | undefined) {
-        const getUser = jest.spyOn(target['userDatabaseService'], 'getUser')
-        getUser.mockImplementation(() => Promise.resolve(user))
-    }
-
-    function setupGetToken(token: string | undefined) {
-        jest.spyOn(target['googleSheetsService'], 'getCurrentOrRefreshedToken').mockImplementation(
-            () => Promise.resolve(token ? { token, userId: '42' } : undefined),
-        )
-    }
-
-    function setupGetTasks() {
-        jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() =>
-            Promise.resolve([buildTask()]),
-        )
-    }
 })

--- a/test/e2e/export.e2e-spec.ts
+++ b/test/e2e/export.e2e-spec.ts
@@ -4,8 +4,8 @@ import request from 'supertest'
 
 import { CardActions as SheetCardActions } from '../../src/constants/card-actions'
 import { GoogleSheetsService } from '../../src/services/google-sheets.service'
-import { UserDatabaseService } from '../../src/services/user-database.service'
 import { buildUser } from '../fixtures'
+import { setupGetToken, setupGetUser } from '../setups'
 
 import { createTestApp } from './helpers'
 
@@ -23,13 +23,42 @@ describe('export e2e tests', () => {
     })
 
     it('returns the no tasks card if no tasks for the specified project', () => {
-        jest.spyOn(UserDatabaseService.prototype, 'getUser').mockImplementation(() =>
-            Promise.resolve(buildUser()),
-        )
-        jest.spyOn(GoogleSheetsService.prototype, 'getCurrentOrRefreshedToken').mockImplementation(
-            () => Promise.resolve({ token: 'token', userId: '42' }),
-        )
+        setupGetUser(buildUser())
+        setupGetToken('token')
+
         jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() => Promise.resolve([]))
+
+        return request(app.getHttpServer())
+            .post('/process')
+            .send({
+                context: { user: { id: 42 }, theme: 'light' },
+                action: {
+                    actionType: 'submit',
+                    actionId: SheetCardActions.Export,
+                    params: {
+                        source: 'project',
+                        sourceId: 1234,
+                        url: 'https://google.com',
+                        content: 'My Project',
+                        contentPlain: 'My Project',
+                    },
+                    inputs: {
+                        'Input.completed': 'true',
+                    },
+                },
+            })
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .then((response) => {
+                const body = response.body as DoistCardResponse
+                expect(body.card).toBeDefined()
+                expect(JSON.stringify(body)).toMatch(/\*\*My Project\*\* has no tasks to export/)
+            })
+    })
+
+    it('returns the error card if inputs are not present (should not happen, but you never know)', () => {
+        setupGetUser(buildUser())
+        setupGetToken('token')
 
         return request(app.getHttpServer())
             .post('/process')
@@ -47,12 +76,93 @@ describe('export e2e tests', () => {
                     },
                 },
             })
-            .expect(200)
+            .expect(400)
             .expect('Content-Type', /json/)
             .then((response) => {
                 const body = response.body as DoistCardResponse
                 expect(body.card).toBeDefined()
-                expect(JSON.stringify(body)).toMatch(/\*\*My Project\*\* has no tasks to export/)
+
+                const json = JSON.stringify(body)
+                expect(json).toMatch(/Unfortunately, it looks like something went wrong./)
+                expect(json).not.toMatch(/Retry/)
+            })
+    })
+
+    it('returns the error card if talking to Todoist fails', () => {
+        setupGetUser(buildUser())
+        setupGetToken('token')
+
+        jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() => {
+            throw new Error('Error talking to Todoist')
+        })
+
+        return request(app.getHttpServer())
+            .post('/process')
+            .send({
+                context: { user: { id: 42 }, theme: 'light' },
+                action: {
+                    actionType: 'submit',
+                    actionId: SheetCardActions.Export,
+                    params: {
+                        source: 'project',
+                        sourceId: 1234,
+                        url: 'https://google.com',
+                        content: 'My Project',
+                        contentPlain: 'My Project',
+                    },
+                    inputs: {
+                        'Input.completed': 'true',
+                    },
+                },
+            })
+            .expect(500)
+            .expect('Content-Type', /json/)
+            .then((response) => {
+                const body = response.body as DoistCardResponse
+                expect(body.card).toBeDefined()
+
+                const json = JSON.stringify(body)
+                expect(json).toMatch(/Unfortunately, it looks like something went wrong./)
+                expect(json).toMatch(/Retry/)
+            })
+    })
+
+    it('returns the error card if talking to Google fails', () => {
+        setupGetUser(buildUser())
+        setupGetToken('token')
+
+        jest.spyOn(GoogleSheetsService.prototype, 'exportToSheets').mockImplementation(() => {
+            throw new Error('Generic error talking to Google')
+        })
+
+        return request(app.getHttpServer())
+            .post('/process')
+            .send({
+                context: { user: { id: 42 }, theme: 'light' },
+                action: {
+                    actionType: 'submit',
+                    actionId: SheetCardActions.Export,
+                    params: {
+                        source: 'project',
+                        sourceId: 1234,
+                        url: 'https://google.com',
+                        content: 'My Project',
+                        contentPlain: 'My Project',
+                    },
+                    inputs: {
+                        'Input.completed': 'true',
+                    },
+                },
+            })
+            .expect(500)
+            .expect('Content-Type', /json/)
+            .then((response) => {
+                const body = response.body as DoistCardResponse
+                expect(body.card).toBeDefined()
+
+                const json = JSON.stringify(body)
+                expect(json).toMatch(/Unfortunately, it looks like something went wrong./)
+                expect(json).toMatch(/Retry/)
             })
     })
 })

--- a/test/setups.ts
+++ b/test/setups.ts
@@ -1,0 +1,25 @@
+import { TodoistApi } from '@doist/todoist-api-typescript'
+
+import { GoogleSheetsService } from '../src/services/google-sheets.service'
+import { UserDatabaseService } from '../src/services/user-database.service'
+
+import { buildTask } from './fixtures'
+
+import type { User } from '../src/entities/user.entity'
+
+export function setupGetUser(user: User | undefined) {
+    const getUser = jest.spyOn(UserDatabaseService.prototype, 'getUser')
+    getUser.mockImplementation(() => Promise.resolve(user))
+}
+
+export function setupGetToken(token: string | undefined) {
+    jest.spyOn(GoogleSheetsService.prototype, 'getCurrentOrRefreshedToken').mockImplementation(() =>
+        Promise.resolve(token ? { token, userId: '42' } : undefined),
+    )
+}
+
+export function setupGetTasks() {
+    jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() =>
+        Promise.resolve([buildTask()]),
+    )
+}


### PR DESCRIPTION
## Overview

Adds in error handling for calls made to Todoist and Google which will display the standard error card we (Doist) have been using in our extensions. I've added the error images we've been using although they are the old Twist ones, so we probably want to update those (I've added it to #5)

![image](https://user-images.githubusercontent.com/25244878/183927404-ffdc3370-c073-4fcd-a034-d807418b0c0a.png)
Note: Image doesn't show here because I just accessed it through production which won't display images.

The actual error reporting to sentry will be taken care of automatically because we are using the `ErrorModule` from the server package ([ref](https://github.com/Doist/event-integrations/blob/main/core/src/modules/error.module.ts)). All we need to do is throw an `IntegrationException` and the rest is taken care of. For unhandled server extensions, these too are automatically taken care of by the Sentry Interceptor that is used in the [`CoreModule`](https://github.com/Doist/event-integrations/blob/main/core/src/modules/core.module.ts#L15).

## Reference

Fixes: #18 

## Test Plan

### Pre-requisites 

To display the UI extension:
- Go to https://staging.todoist.com/app_console
- Create a new integration
- Scroll down to the UI Extensions section of that integration and add a new one. This should be of type Context menu. The URL should be a locally running [ngrok](https://ngrok.com/) or [localtunnel](https://www.npmjs.com/package/localtunnel) instance
- Copy the verification token in the integration and put it in your `.env` file in the `VERIFICATION_TOKENS` field. 
- Start the extension service (`npm run start:dev`) and start ngrok/localtunnel.
- Go to https://staging.todoist.com 
- Click a context menu of a project, then extensions, then whatever you called your UI extension

For the Google Authentication side, please follow the instructions in the readme on how to create the Google App.

### Actual testing

To test the lack of inputs (something that should never happen as it means todoist-web has broken), you can just say `if (!action.inputs || true)` in `actions.service.ts:93` then try and do an export (actually click the button).

To test the Todoist API side, just put an invalid token into your .env file and try and do an export.

To test the Google API side, update the `GOOGLE_API_KEY` in your .env to something invalid (once you've signed in).

## Creator Checklist

-   [ ] Reasonable test coverage
-   [ ] _(bugs)_ Re-test fix before asking for review

## Reviewer Checklist

-   [ ] Code-level review
-   [ ] Smoke testing
-   [ ] UX feedback (check if not applicable)
