### PR TITLE
chore: Renames `content` to `taskName`

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,7 @@ export const ExportOptionsNames = [
 
 export const NonOptionalExportOptionsNames = [
     'taskId',
-    'content',
+    'taskName',
     'sectionId',
     'parentTaskId',
 ] as const

--- a/src/utils/csv-helpers.spec.ts
+++ b/src/utils/csv-helpers.spec.ts
@@ -15,7 +15,7 @@ describe('CSV Helpers', () => {
 
                 expect(result).toEqual(
                     toCustomCSV(
-                        'taskId,content,sectionId,parentTaskId,completed,due,priority,description,parentTask,section,assignee,createdDate',
+                        'taskId,taskName,sectionId,parentTaskId,completed,due,priority,description,parentTask,section,assignee,createdDate',
                     ),
                 )
             })
@@ -35,7 +35,7 @@ describe('CSV Helpers', () => {
                         createdDate: false,
                     },
                 })
-                expect(result).toEqual(toCustomCSV('taskId,content,sectionId,parentTaskId'))
+                expect(result).toEqual(toCustomCSV('taskId,taskName,sectionId,parentTaskId'))
             })
 
             it('displays correct headers when some options are turned off', () => {
@@ -55,7 +55,7 @@ describe('CSV Helpers', () => {
                 })
 
                 expect(result).toEqual(
-                    toCustomCSV('taskId,content,sectionId,parentTaskId,completed,due,description'),
+                    toCustomCSV('taskId,taskName,sectionId,parentTaskId,completed,due,description'),
                 )
             })
         })

--- a/src/utils/csv-helpers.ts
+++ b/src/utils/csv-helpers.ts
@@ -44,7 +44,7 @@ function createTaskRow(
             case 'taskId':
                 items.push(task.id.toString())
                 break
-            case 'content':
+            case 'taskName':
                 items.push(sanitiseText(task.content))
                 break
             case 'sectionId':


### PR DESCRIPTION
## Overview

Was asked by @hfauq to rename `content` to `taskName`.

## Reference

https://twist.com/a/1585/ch/336653/t/3826156/c/79248216

## Test Plan

<!-- Describe what should the reviewer test. If a specific setup is required, describe it to help the reviewer hit the ground running. -->

## Creator Checklist

-   [ ] Reasonable test coverage
-   [ ] _(bugs)_ Re-test fix before asking for review

## Reviewer Checklist

-   [ ] Code-level review
-   [ ] Smoke testing
-   [ ] UX feedback (check if not applicable)
