### PR TITLE
ci: Remove deprecated set-output usage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v3
 
             - run: |
-                  echo ::set-output name=short::$(git rev-parse --short ${{ github.sha }})
+                  echo "short=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
               id: git
 
             - name: Set up Docker Buildx
@@ -71,7 +71,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - run: |
-                  echo ::set-output name=short::$(git rev-parse --short ${{ github.sha }})
+                  echo "short=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
               id: git
             - name: Configure AWS Credentials
               uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Overview

`set-output` is being deprecated and will cause failures June 2023. Updated to the recommended approach.

## Reference

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/Doist/infrastructure-backlog/issues/481

