### PR TITLE
chore: tighten ci permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+aws/* @doist/Infrastructure
+.github/workflows/* @doist/Infrastructure
+server.Dockerfile Makefile @doist/Infrastructure

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 aws/* @doist/Infrastructure
 .github/workflows/* @doist/Infrastructure
-server.Dockerfile Makefile @doist/Infrastructure
+server.Dockerfile @doist/Infrastructure
+Makefile @doist/Infrastructure

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,15 +6,18 @@ concurrency:
     group: audit-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     audit:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.4.0
 
             - name: Configure doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
               with:
                   node-version-file: '.nvmrc'
                   scope: '@doist'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,29 +25,29 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.4.0
 
             - run: |
                   echo "short=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
               id: git
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
+              uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
               with:
                   role-duration-seconds: 900
                   role-to-assume: ${{ env.AWS_ROLE }}
                   aws-region: ${{ env.AWS_REGION }}
 
             - name: Login to AWS Container Registry
-              uses: docker/login-action@v1
+              uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a    # v2.1.0
               with:
                   registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
 
             - name: Build and Push Docker
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
               with:
                   context: .
                   file: server.Dockerfile
@@ -69,18 +69,18 @@ jobs:
         needs: [build]
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.4.0
             - run: |
                   echo "short=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
               id: git
             - name: Configure AWS Credentials
-              uses: aws-actions/configure-aws-credentials@v1
+              uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
               with:
                   role-duration-seconds: 900
                   role-to-assume: ${{ env.AWS_ROLE }}
                   aws-region: ${{ env.AWS_REGION }}
             - name: Deploy CloudFormation Stack
-              uses: aws-actions/aws-cloudformation-github-deploy@v1
+              uses: aws-actions/aws-cloudformation-github-deploy@6901756eb70595fa9c1169141934562aa4e86f2a # v1.1.0
               with:
                   name: ${{ env.INTEGRATION }}-${{ env.ENV }}
                   template: aws/cloudformation.yml

--- a/.github/workflows/google-sheets-ci.yml
+++ b/.github/workflows/google-sheets-ci.yml
@@ -10,14 +10,18 @@ concurrency:
     group: google-sheets-ci-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     ci-google-sheets:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.4.0
 
             - name: Configure doist package repository
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
               with:
                   node-version: '16'
 

--- a/aws/cloudformation.yml
+++ b/aws/cloudformation.yml
@@ -163,7 +163,6 @@ Resources:
                         ValueFrom: 'arn:aws:secretsmanager:us-east-1:011833101604:secret:integrations/todoist-google-sheets/secrets-4oa5bD:DB_ENCRYPTION_ALGORITHM::'
                       - Name: DB_ENCRYPTION_IV_LENGTH
                         ValueFrom: 'arn:aws:secretsmanager:us-east-1:011833101604:secret:integrations/todoist-google-sheets/secrets-4oa5bD:DB_ENCRYPTION_IV_LENGTH::'
-
                   Ulimits:
                       - Name: nofile
                         HardLimit: 5000
@@ -201,30 +200,8 @@ Resources:
                             Action:
                                 - 'secretsmanager:GetSecretValue'
                             Resource:
-                                - !Sub 'arn:aws:secretsmanager:*:${AWS::AccountId}:secret:integrations/${ServiceName}/*'
-                          - Effect: Allow
-                            Action:
-                                - 'secretsmanager:ListSecrets'
-                            Resource:
-                                - '*'
-
-    # IAM role for GitHub actions
-    PolicyAS:
-        Type: AWS::IAM::ManagedPolicy
-        Properties:
-            PolicyDocument:
-                Version: 2012-10-17
-                Statement:
-                    - Effect: Allow
-                      Action:
-                          - application-autoscaling:DescribeScalableTargets
-                          - application-autoscaling:RegisterScalableTarget
-                          - application-autoscaling:DeregisterScalableTarget
-                          - application-autoscaling:DescribeScalingPolicies
-                          - application-autoscaling:PutScalingPolicy
-                          - application-autoscaling:DeleteScalingPolicy
-                          - application-autoscaling:DescribeScheduledActions
-                      Resource: '*'
+                                - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:integrations/${ServiceName}/secrets-4oa5bD'
+                                - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:integrations/${ServiceName}/mysql-woNqVM'
 
     PolicyCFN:
         Type: AWS::IAM::ManagedPolicy
@@ -236,12 +213,12 @@ Resources:
                       Action:
                           - 'cloudformation:*'
                       Resource:
-                          - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/${ServiceName}-${Environment}/*'
+                          - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${ServiceName}-${Environment}/*'
                     - Effect: Deny
                       Action:
                           - 'cloudformation:DeleteStack'
                       Resource:
-                          - !Sub 'arn:aws:cloudformation:*:${AWS::AccountId}:stack/${ServiceName}-${Environment}/*'
+                          - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${ServiceName}-${Environment}/*'
 
     PolicyECS:
         Type: AWS::IAM::ManagedPolicy
@@ -254,10 +231,8 @@ Resources:
                           - ecs:UpdateService
                           - ecs:CreateService
                           - ecs:DeleteService
-                          - ecs:UntagResource
-                          - ecs:TagResource
                       Resource:
-                          - !Sub 'arn:aws:ecs:*:${AWS::AccountId}:service/${Cluster}/${ServiceName}*'
+                          - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/${Cluster}/${ServiceName}'
                     - Effect: Allow
                       Action:
                           - ecr:GetDownloadUrlForLayer
@@ -268,7 +243,7 @@ Resources:
                           - ecr:BatchCheckLayerAvailability
                           - ecr:PutImage
                       Resource:
-                          - !Sub 'arn:aws:ecr:*:${AWS::AccountId}:repository/${ServiceName}'
+                          - !Sub 'arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ServiceName}'
                     - Effect: Allow
                       Action:
                           - ecs:RegisterTaskDefinition
@@ -276,6 +251,11 @@ Resources:
                           - ecs:DescribeServices
                           - ecr:GetAuthorizationToken
                           - ecs:DescribeTaskDefinition
+                      Resource:
+                          - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/${ServiceName}:*'
+                    - Effect: Allow
+                      Action:
+                          - ecr:GetAuthorizationToken
                       Resource: '*'
 
     PolicyIAM:
@@ -288,13 +268,8 @@ Resources:
                       Action:
                           - iam:PassRole
                           - iam:GetRole
-                          - iam:ListPolicyVersions
-                          - iam:GetPolicy
-                          - iam:CreatePolicyVersion
-                          - iam:DeletePolicyVersion
                       Resource:
-                          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ServiceName}-*'
-                          - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/${ServiceName}-*'
+                          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ServiceName}-${Environment}-execution'
                           - arn:aws:iam::011833101604:role/ecsEventsRole
 
     GitHubRoleCI:
@@ -310,11 +285,26 @@ Resources:
                       Condition:
                           StringLike:
                               token.actions.githubusercontent.com:sub: !Sub 'repo:Doist/${ServiceName}:ref:refs/heads/main'
+                    - Effect: Deny
+                      Action:
+                        - application-autoscaling:*
+                        - autoscaling-plans:*
+                        - cloudwatch:*
+                        - events:*
+                        - logs:*
+                        - sqs:*
+                        - sns:*
+                        - ecs:*
+                        - iam:*
+                      Condition:
+                        ForAllValues:StringNotEqualsIfExists:
+                            aws:CalledVia:
+                                - cloudformation.amazonaws.com
+                      Resource: '*'
             ManagedPolicyArns:
                 - !Ref PolicyECS
                 - !Ref PolicyCFN
                 - !Ref PolicyIAM
-                - !Ref PolicyAS
 
     # The service. The service is a resource which allows you to run multiple
     # copies of a type of task, and gather up their logs and metrics, as well


### PR DESCRIPTION
## Overview

* Tighten CI permissions, please see https://github.com/Doist/infrastructure-backlog/issues/492 for details
* Added CODEOWNERS
* Pin 3-rd party actions to SHAs
* Limited scope of workflow token
* Repository settings [Prevented GitHub Actions from creating or approving PR](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests)
* Tighten GH actions permissions 
<img width="845" alt="image" src="https://user-images.githubusercontent.com/197788/208125987-2c7e1102-96c0-4fa4-b33e-50664d167d81.png">


## Reference

 * Fix https://github.com/Doist/infrastructure-backlog/issues/492
