### PR TITLE
chore: Adds index to the Google Sheets User db table

### DIFF
--- a/src/migrations/1700484408073-index-twistId.ts
+++ b/src/migrations/1700484408073-index-twistId.ts
@@ -1,0 +1,15 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class indexTwistId1700484408073 implements MigrationInterface {
+    name = 'indexTwistId1700484408073'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'CREATE INDEX `IDX_bb5c51b9806c01de5b44d0e033` ON `user` (`twistId`)',
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX `IDX_bb5c51b9806c01de5b44d0e033` ON `user`')
+    }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,7 @@ export const NonOptionalExportOptionsNames = [
     'parentTaskId',
 ] as const
 
-export type ExportOptions = typeof ExportOptionsNames[number]
+export type ExportOptions = (typeof ExportOptionsNames)[number]
 
 export type ExportOptionsToUse = Record<ExportOptions, boolean> & {
     includeCompleted: boolean


### PR DESCRIPTION
## Overview

It has recently been made aware that on our db, the `twistId` field was not being indexed which resulted in slow db queries. This PR adds said index.