### PR TITLE
refactor: move to Todoist API v1 (v2 IDs are exported instead of v1 IDs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@doist/integrations-common": "2.0.0",
-                "@doist/todoist-api-typescript": "2.1.2",
+                "@doist/todoist-api-typescript": "4.0.1",
                 "@doist/ui-extensions-core": "4.1.1",
                 "@doist/ui-extensions-server": "3.3.1",
                 "@nestjs/axios": "3.1.2",
@@ -848,26 +848,19 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-2.1.2.tgz",
-            "integrity": "sha512-6aCY8FVERMBQ+hDcADGjz76f8fZwRww3gIg05/KkcGhwqq2nfzQAPJ0d3T2F67yWTRCAmxMSupERqFJbCRXDXA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-4.0.1.tgz",
+            "integrity": "sha512-gbYomR0KSSrDKqNlXFDTrtSglsY4KbpZoMkbPZn2wcn63cGSa7XYuA5BTMW3XCypxWJrJol8l52VhcYgcZ1WhQ==",
             "dependencies": {
-                "axios": "^0.27.0",
-                "axios-case-converter": "^0.11.0",
+                "axios": "^1.0.0",
+                "axios-case-converter": "^1.0.0",
                 "axios-retry": "^3.1.9",
-                "runtypes": "^6.5.0",
                 "ts-custom-error": "^3.2.0",
-                "uuid": "^9.0.0"
-            }
-        },
-        "node_modules/@doist/todoist-api-typescript/node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "uuid": "^9.0.0",
+                "zod": "^3.24.1"
+            },
+            "peerDependencies": {
+                "type-fest": "^4.12.0"
             }
         },
         "node_modules/@doist/todoist-api-typescript/node_modules/uuid": {
@@ -3770,9 +3763,9 @@
             }
         },
         "node_modules/axios-case-converter": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/axios-case-converter/-/axios-case-converter-0.11.1.tgz",
-            "integrity": "sha512-i5hrkBg7SE9jsm2Q+ClznR5DsKcYXChH6Cc3Rhx2p4gdIfJwvvO5/ATcAg/vN2UVzGE2B1eR1O4VuEGkICdJdQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/axios-case-converter/-/axios-case-converter-1.1.1.tgz",
+            "integrity": "sha512-v13pB7cYryh/7f4TKxN/gniD2hwqPQcjip29Hk3J9iwsnA37Rht2Hkn5VyrxynxlKdMNSIfGk6I9D6G28oTRyQ==",
             "dependencies": {
                 "camel-case": "^4.1.1",
                 "header-case": "^2.0.3",
@@ -3780,13 +3773,13 @@
                 "tslib": "^2.3.0"
             },
             "peerDependencies": {
-                "axios": ">=0.23.0 <2.0.0"
+                "axios": ">=1.0.0 <2.0.0"
             }
         },
         "node_modules/axios-case-converter/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/axios-retry": {
             "version": "3.3.1",
@@ -4187,9 +4180,9 @@
             }
         },
         "node_modules/camel-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/camelcase": {
             "version": "5.3.1",
@@ -4231,9 +4224,9 @@
             }
         },
         "node_modules/capital-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -4859,9 +4852,9 @@
             }
         },
         "node_modules/dot-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/dotenv": {
             "version": "16.0.3",
@@ -6497,6 +6490,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/globals/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/globby": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -6796,9 +6801,9 @@
             }
         },
         "node_modules/header-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/headers-polyfill": {
             "version": "3.1.2",
@@ -10269,9 +10274,9 @@
             }
         },
         "node_modules/lower-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -10682,9 +10687,9 @@
             }
         },
         "node_modules/no-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/node-abort-controller": {
             "version": "3.1.1",
@@ -11252,9 +11257,9 @@
             }
         },
         "node_modules/pascal-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -11892,11 +11897,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/runtypes": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.6.0.tgz",
-            "integrity": "sha512-ddM7sgB3fyboDlBzEYFQ04L674sKjbs4GyW2W32N/5Ae47NRd/GyMASPC2PFw8drPHYGEcZ0mZ26r5RcB8msfQ=="
-        },
         "node_modules/rxjs": {
             "version": "7.8.1",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -12176,9 +12176,9 @@
             }
         },
         "node_modules/snake-case/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -13041,12 +13041,12 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
+            "version": "4.40.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+            "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
+            "peer": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -13414,9 +13414,9 @@
             }
         },
         "node_modules/upper-case-first/node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -13910,6 +13910,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.24.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+            "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     },
@@ -14493,27 +14501,18 @@
             "requires": {}
         },
         "@doist/todoist-api-typescript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-2.1.2.tgz",
-            "integrity": "sha512-6aCY8FVERMBQ+hDcADGjz76f8fZwRww3gIg05/KkcGhwqq2nfzQAPJ0d3T2F67yWTRCAmxMSupERqFJbCRXDXA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-4.0.1.tgz",
+            "integrity": "sha512-gbYomR0KSSrDKqNlXFDTrtSglsY4KbpZoMkbPZn2wcn63cGSa7XYuA5BTMW3XCypxWJrJol8l52VhcYgcZ1WhQ==",
             "requires": {
-                "axios": "^0.27.0",
-                "axios-case-converter": "^0.11.0",
+                "axios": "^1.0.0",
+                "axios-case-converter": "^1.0.0",
                 "axios-retry": "^3.1.9",
-                "runtypes": "^6.5.0",
                 "ts-custom-error": "^3.2.0",
-                "uuid": "^9.0.0"
+                "uuid": "^9.0.0",
+                "zod": "^3.24.1"
             },
             "dependencies": {
-                "axios": {
-                    "version": "0.27.2",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-                    "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-                    "requires": {
-                        "follow-redirects": "^1.14.9",
-                        "form-data": "^4.0.0"
-                    }
-                },
                 "uuid": {
                     "version": "9.0.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -16767,9 +16766,9 @@
             }
         },
         "axios-case-converter": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/axios-case-converter/-/axios-case-converter-0.11.1.tgz",
-            "integrity": "sha512-i5hrkBg7SE9jsm2Q+ClznR5DsKcYXChH6Cc3Rhx2p4gdIfJwvvO5/ATcAg/vN2UVzGE2B1eR1O4VuEGkICdJdQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/axios-case-converter/-/axios-case-converter-1.1.1.tgz",
+            "integrity": "sha512-v13pB7cYryh/7f4TKxN/gniD2hwqPQcjip29Hk3J9iwsnA37Rht2Hkn5VyrxynxlKdMNSIfGk6I9D6G28oTRyQ==",
             "requires": {
                 "camel-case": "^4.1.1",
                 "header-case": "^2.0.3",
@@ -16778,9 +16777,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -17083,9 +17082,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -17112,9 +17111,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -17597,9 +17596,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -18856,6 +18855,14 @@
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
+                }
             }
         },
         "globby": {
@@ -19077,9 +19084,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -21829,9 +21836,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -22147,9 +22154,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -22580,9 +22587,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -23040,11 +23047,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "runtypes": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.6.0.tgz",
-            "integrity": "sha512-ddM7sgB3fyboDlBzEYFQ04L674sKjbs4GyW2W32N/5Ae47NRd/GyMASPC2PFw8drPHYGEcZ0mZ26r5RcB8msfQ=="
-        },
         "rxjs": {
             "version": "7.8.1",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -23265,9 +23267,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -23897,10 +23899,10 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true
+            "version": "4.40.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+            "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
+            "peer": true
         },
         "type-is": {
             "version": "1.6.18",
@@ -24096,9 +24098,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -24483,6 +24485,11 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
+        },
+        "zod": {
+            "version": "3.24.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+            "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "prettier": "@doist/prettier-config",
     "dependencies": {
         "@doist/integrations-common": "2.0.0",
-        "@doist/todoist-api-typescript": "2.1.2",
+        "@doist/todoist-api-typescript": "4.0.1",
         "@doist/ui-extensions-core": "4.1.1",
         "@doist/ui-extensions-server": "3.3.1",
         "@nestjs/axios": "3.1.2",

--- a/src/services/actions.service.spec.ts
+++ b/src/services/actions.service.spec.ts
@@ -121,7 +121,7 @@ describe('ActionsService', () => {
             setupGetAppToken('kwijibo')
 
             jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() =>
-                Promise.resolve([]),
+                Promise.resolve({ results: [], nextCursor: null }),
             )
 
             const noTasksCard = jest.spyOn(target['adaptiveCardsService'], 'noTasksCard')
@@ -199,7 +199,7 @@ describe('ActionsService', () => {
 
             const getSections = jest
                 .spyOn(TodoistApi.prototype, 'getSections')
-                .mockImplementation(() => Promise.resolve([]))
+                .mockImplementation(() => Promise.resolve({ results: [], nextCursor: null }))
 
             await target.export({
                 context: { user: { id: 42 } as DoistCardContextUser, theme: 'light' },

--- a/src/services/todoist.service.spec.ts
+++ b/src/services/todoist.service.spec.ts
@@ -33,7 +33,7 @@ describe('TodoistService', () => {
             projectId: '123',
             token: 'kwijibo',
         })
-        expect(result).toEqual([])
+        expect(result).toEqual({ tasks: [], completedInfo: [] })
         expect(httpServer).toHaveBeenCalledTimes(1)
     })
 

--- a/src/services/todoist.service.ts
+++ b/src/services/todoist.service.ts
@@ -1,3 +1,5 @@
+import { Section, TodoistApi, User } from '@doist/todoist-api-typescript'
+
 import { HttpService } from '@nestjs/axios'
 import { Injectable } from '@nestjs/common'
 import { lastValueFrom } from 'rxjs'
@@ -41,68 +43,183 @@ export type SyncTask = {
     duration: null
 }
 
+export type CompletedInfo = {
+    item_id?: string
+    project_id?: string
+    section_id?: string
+    completed_items: number
+}
+
+type CompletedTasksResponse = {
+    total: number
+    completed_info: CompletedInfo[]
+    has_more: boolean
+    next_cursor: string | null
+    items: SyncTask[]
+}
+
 @Injectable()
 export class TodoistService {
     constructor(private readonly httpService: HttpService) {}
 
+    async getProjectTasks(params: { token: string; projectId: string }): Promise<Task[]> {
+        const { token, projectId } = params
+        const todoistClient = new TodoistApi(token)
+
+        return this.fetchAllPages<Task>((cursor) =>
+            todoistClient.getTasks({
+                projectId,
+                ...(cursor ? { cursor } : {}),
+            }),
+        )
+    }
+
+    async getProjectSections(params: { token: string; projectId: string }): Promise<Section[]> {
+        const { token, projectId } = params
+        const todoistClient = new TodoistApi(token)
+
+        return this.fetchAllPages<Section>((cursor) =>
+            todoistClient.getSections({
+                projectId,
+                ...(cursor ? { cursor } : {}),
+            }),
+        )
+    }
+
+    async getProjectCollaborators(params: { token: string; projectId: string }): Promise<User[]> {
+        const { token, projectId } = params
+        const todoistClient = new TodoistApi(token)
+
+        return this.fetchAllPages<User>((cursor) =>
+            todoistClient.getProjectCollaborators(projectId, {
+                ...(cursor ? { cursor } : {}),
+            }),
+        )
+    }
+
+    private async fetchAllPages<T>(
+        fetchFn: (cursor?: string | null) => Promise<{ results: T[]; nextCursor: string | null }>,
+    ): Promise<T[]> {
+        let allResults: T[] = []
+        let nextCursor: string | null | undefined = undefined
+
+        do {
+            const response: { results: T[]; nextCursor: string | null } = await fetchFn(nextCursor)
+
+            allResults = [...allResults, ...response.results]
+            nextCursor = response.nextCursor
+        } while (nextCursor !== null)
+
+        return allResults
+    }
+
     async getCompletedTasks({
         projectId,
         token,
+        taskId,
+        sectionId,
     }: {
         token: string
-        projectId: string
-    }): Promise<Task[]> {
-        const completedTasks = await this.getCompletedTasksInternal({ token, projectId })
+        projectId?: string
+        taskId?: string
+        sectionId?: string
+    }): Promise<{ tasks: Task[]; completedInfo: CompletedInfo[] }> {
+        try {
+            const result = await this.getCompletedTasksInternal({
+                token,
+                projectId,
+                taskId,
+                sectionId,
+            })
 
-        return completedTasks.map((task) => this.getTaskFromQuickAddResponse(task))
+            return {
+                tasks: result.items.map((task) => this.getTaskFromQuickAddResponse(task)),
+                completedInfo: result.completedInfo,
+            }
+        } catch (error: unknown) {
+            return { tasks: [], completedInfo: [] }
+        }
     }
 
     private async getCompletedTasksInternal({
         projectId,
         token,
-        cursor,
+        taskId,
+        sectionId,
     }: {
         token: string
-        projectId: string
-        cursor?: string
-    }): Promise<SyncTask[]> {
-        const response = await lastValueFrom(
-            this.httpService.get<{
-                has_more: boolean
-                next_cursor?: string
-                items: SyncTask[]
-            }>(
-                // this endpoint is not publicly documented.
-                // we should eventually move to one of the Todoist API v1 endpoints
-                // for fetching completed tasks (e.g `/tasks/completed/by_parent`).
-                // we're only using this endpoint because at the moment (April 2025),
-                // the v1 endpoints do not return data for unjoined projects.
-                'https://api.todoist.com/api/v9.223/archive/items',
-                {
-                    headers: { Authorization: `Bearer ${token}` },
-                    params: {
-                        limit: LIMIT,
-                        project_id: projectId,
-                        ...(cursor ? { cursor } : {}),
+        projectId?: string
+        taskId?: string
+        sectionId?: string
+    }): Promise<{ items: SyncTask[]; completedInfo: CompletedInfo[] }> {
+        const allItems: SyncTask[] = []
+        const allCompletedInfo: CompletedInfo[] = []
+
+        const fetchPage = async (
+            cursor?: string | null,
+        ): Promise<{
+            results: SyncTask[]
+            nextCursor: string | null
+            completedInfo: CompletedInfo[]
+        }> => {
+            const response = await lastValueFrom(
+                this.httpService.get<CompletedTasksResponse>(
+                    // this endpoint is not publicly documented.
+                    // we should eventually move to one of the Todoist API v1 endpoints
+                    // for fetching completed tasks (e.g `/tasks/completed/by_parent`).
+                    // we're only using this endpoint because at the moment (April 2025),
+                    // the v1 endpoints do not return data for unjoined projects.
+                    'https://api.todoist.com/api/v9.223/archive/items',
+                    {
+                        headers: { Authorization: `Bearer ${token}` },
+                        params: {
+                            limit: LIMIT,
+                            ...(projectId ? { project_id: projectId } : {}),
+                            ...(taskId ? { parent_id: taskId } : {}),
+                            ...(sectionId ? { section_id: sectionId } : {}),
+                            ...(cursor ? { cursor } : {}),
+                        },
                     },
-                },
+                ),
+            )
+
+            return {
+                results: response.data.items,
+                nextCursor: response.data.has_more ? response.data.next_cursor : null,
+                completedInfo: response.data.completed_info,
+            }
+        }
+
+        let nextCursor: string | null | undefined = undefined
+
+        do {
+            const pageResult: {
+                results: SyncTask[]
+                nextCursor: string | null
+                completedInfo: CompletedInfo[]
+            } = await fetchPage(nextCursor)
+
+            allItems.push(...pageResult.results)
+            allCompletedInfo.push(...pageResult.completedInfo)
+            nextCursor = pageResult.nextCursor
+        } while (nextCursor !== null)
+
+        return {
+            items: allItems,
+            completedInfo: allCompletedInfo,
+        }
+    }
+
+    async getCompletedInfo({ token }: { token: string }): Promise<CompletedInfo[]> {
+        const response = await lastValueFrom(
+            this.httpService.post<{ completed_info: CompletedInfo[] }>(
+                'https://api.todoist.com/api/v9.223/sync',
+                { resource_types: ['completed_info'] },
+                { headers: { Authorization: `Bearer ${token}` } },
             ),
         )
 
-        const { data } = response
-        const tasks = data.items
-
-        if (data.has_more && data.next_cursor) {
-            return tasks.concat(
-                await this.getCompletedTasksInternal({
-                    token,
-                    projectId,
-                    cursor: data.next_cursor,
-                }),
-            )
-        }
-
-        return tasks
+        return response.data.completed_info
     }
 
     private getTaskFromQuickAddResponse(responseData: SyncTask): Task {

--- a/src/utils/csv-helpers.spec.ts
+++ b/src/utils/csv-helpers.spec.ts
@@ -129,7 +129,7 @@ describe('CSV Helpers', () => {
 
                 expect(rows[1]).toEqual(
                     toCustomCSV(
-                        '10000001,My awesome task,1234,,false,,1,This is a description,,My awesome section,Lukas Frito (12345),2022-08-05T00:00:00.000Z,2022-08-06T00:00:00.000Z',
+                        '10000001,My awesome task,1234,,false,2022-08-09,1,This is a description,,My awesome section,Lukas Frito (12345),2022-08-05T00:00:00.000Z,2022-08-06T00:00:00.000Z',
                     ),
                 )
             })
@@ -170,7 +170,7 @@ describe('CSV Helpers', () => {
 
                 expect(rows[1]).toEqual(
                     toCustomCSV(
-                        '10000001,My awesome task,1234,,false,,1,,Lukas Frito (12345),2022-08-05T00:00:00.000Z',
+                        '10000001,My awesome task,1234,,false,2022-08-09,1,,Lukas Frito (12345),2022-08-05T00:00:00.000Z',
                     ),
                 )
             })
@@ -213,7 +213,7 @@ describe('CSV Helpers', () => {
 
                 expect(rows[1]).toEqual(
                     toCustomCSV(
-                        '10000001,My awesome task On two lines,1234,,false,,3,This is a description Also on two lines,,My awesome section,Lukas Frito (12345),2022-08-05T00:00:00.000Z',
+                        '10000001,My awesome task On two lines,1234,,false,2022-08-09,3,This is a description Also on two lines,,My awesome section,Lukas Frito (12345),2022-08-05T00:00:00.000Z',
                     ),
                 )
             })
@@ -255,7 +255,7 @@ describe('CSV Helpers', () => {
                 const rows = result.split('\n')
 
                 expect(rows[1]).toEqual(
-                    '10000001...---...My awesome task, but with a comma...---...1234...---......---...false...---......---...1...---...This is a description Also on two lines...---......---...My awesome section...---...Lukas Frito (12345)...---...2022-08-05T00:00:00.000Z',
+                    '10000001...---...My awesome task, but with a comma...---...1234...---......---...false...---...2022-08-09...---...1...---...This is a description Also on two lines...---......---...My awesome section...---...Lukas Frito (12345)...---...2022-08-05T00:00:00.000Z',
                 )
             })
         })

--- a/test/e2e/export.e2e-spec.ts
+++ b/test/e2e/export.e2e-spec.ts
@@ -5,8 +5,9 @@ import request from 'supertest'
 
 import { CardActions as SheetCardActions } from '../../src/constants/card-actions'
 import { GoogleSheetsService } from '../../src/services/google-sheets.service'
+import { TodoistService } from '../../src/services/todoist.service'
 import { buildUser } from '../fixtures'
-import { setupGetGoogleToken, setupGetUser } from '../setups'
+import { setupGetGoogleToken, setupGetTasks, setupGetUser } from '../setups'
 
 import { createTestApp } from './helpers'
 
@@ -18,6 +19,26 @@ describe('export e2e tests', () => {
 
     afterAll(() => app.close())
 
+    beforeEach(() => {
+        jest.spyOn(TodoistApi.prototype, 'getTasks').mockResolvedValue({
+            results: [],
+            nextCursor: null,
+        })
+        jest.spyOn(TodoistApi.prototype, 'getSections').mockResolvedValue({
+            results: [],
+            nextCursor: null,
+        })
+        jest.spyOn(TodoistApi.prototype, 'getProjectCollaborators').mockResolvedValue({
+            results: [],
+            nextCursor: null,
+        })
+        jest.spyOn(TodoistApi.prototype, 'getProjectCollaborators').mockResolvedValue({
+            results: [],
+            nextCursor: null,
+        })
+        jest.spyOn(TodoistService.prototype, 'getCompletedTasks').mockResolvedValue([])
+    })
+
     beforeAll(async () => {
         const { appModule } = await createTestApp()
         app = appModule
@@ -27,7 +48,10 @@ describe('export e2e tests', () => {
         setupGetUser(buildUser())
         setupGetGoogleToken('token')
 
-        jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() => Promise.resolve([]))
+        jest.spyOn(TodoistApi.prototype, 'getTasks').mockResolvedValue({
+            results: [],
+            nextCursor: null,
+        })
 
         return request(app.getHttpServer())
             .post('/process')
@@ -135,6 +159,7 @@ describe('export e2e tests', () => {
     it('returns the error card if talking to Google fails', () => {
         setupGetUser(buildUser())
         setupGetGoogleToken('token')
+        setupGetTasks()
 
         jest.spyOn(GoogleSheetsService.prototype, 'exportToSheets').mockImplementation(() => {
             throw new Error('Generic error talking to Google')

--- a/test/e2e/export.e2e-spec.ts
+++ b/test/e2e/export.e2e-spec.ts
@@ -36,7 +36,10 @@ describe('export e2e tests', () => {
             results: [],
             nextCursor: null,
         })
-        jest.spyOn(TodoistService.prototype, 'getCompletedTasks').mockResolvedValue([])
+        jest.spyOn(TodoistService.prototype, 'getCompletedTasks').mockResolvedValue({
+            tasks: [],
+            completedInfo: [],
+        })
     })
 
     beforeAll(async () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -37,7 +37,6 @@ export const buildOptions = build<ExportOptionsToUse>('ExportOptionsToUse', {
 export const buildTask = build<Task>('Task', {
     fields: {
         id: sequence((num) => String(num + 10000000)),
-        commentCount: 0,
         content: perBuild(() => faker.lorem.sentence()),
         isCompleted: false,
         createdAt: perBuild(() => faker.date.recent().toDateString()),
@@ -48,8 +47,13 @@ export const buildTask = build<Task>('Task', {
         projectId: '12345',
         sectionId: '12345',
         creatorId: '123',
-        assigneeId: undefined,
+        assigneeId: null,
         url: 'https://todoist.com/showTask?id=12345',
+        parentId: null,
+        deadline: null,
+        duration: null,
+        due: null,
+        assignerId: null,
     },
 })
 
@@ -57,8 +61,15 @@ export const buildSection = build<Section>('Section', {
     fields: {
         id: sequence((num) => String(num + 10000000)),
         name: perBuild(() => faker.lorem.sentence()),
-        order: 0,
         projectId: '12345',
+        userId: '123',
+        isDeleted: false,
+        addedAt: perBuild(() => faker.date.recent().toDateString()),
+        updatedAt: perBuild(() => faker.date.recent().toDateString()),
+        isCollapsed: false,
+        isArchived: false,
+        archivedAt: null,
+        sectionOrder: 0,
     },
 })
 

--- a/test/setups.ts
+++ b/test/setups.ts
@@ -25,6 +25,6 @@ export function setupGetAppToken(token: string | never) {
 
 export function setupGetTasks() {
     jest.spyOn(TodoistApi.prototype, 'getTasks').mockImplementation(() =>
-        Promise.resolve([buildTask()]),
+        Promise.resolve({ results: [buildTask()], nextCursor: null }),
     )
 }


### PR DESCRIPTION
## Overview

<!-- Brief description of the bug fix, feature or enhancement implemented in this PR. If there are any pitfalls or trade-offs you had to make, mention them. -->

This PR refactors the integration to use the latest Typescript API SDK (4.0.2). This version only deals with v2 IDs, meaning that the exported task rows will only contain v2 IDs (as requested in https://github.com/Doist/Issues/issues/16751).

The most challenging part was to ensure that all project completed tasks are fetched, including sub-tasks from active and completed tasks. Previously the integration hit the `items/get_completed` endpoint, which returned all project tasks, but that endpoint was removed in [v9.7](https://github.com/Doist/Todoist/blob/main/todoist/apps/api_version.py#L207-L211), forcing us to switch to the `/archive/items` endpoint, which only returns tasks for the ancestor specified as query param.

## Reference

<!-- GitHub issues, specs, Zeplin/Figma mockups, ... -->

- Closes https://github.com/Doist/Issues/issues/16751

## Test Plan

<!-- Describe what should the reviewer test. If a specific setup is required, describe it to help the reviewer hit the ground running. -->

Setting up the integration locally takes a bit, so perhaps a code review is enough.

- Run the integration locally
- Export a project that has tasks, sections, and completed tasks of every kind (project-level, task-level, section-level and compiled task-level).
- [x] All task rows are exported. Compare the generated sheet with the one produced by the current version in production. 

##  Demo


https://github.com/user-attachments/assets/c3173b58-ca6d-4691-9776-a2ad8d33984c



## Creator Checklist

-   [x] Reasonable test coverage
-   [x] _(bugs)_ Re-test fix before asking for review

## Reviewer Checklist

-   [ ] Code-level review
-   [ ] Smoke testing
-   [ ] UX feedback (check if not applicable)
