### PR TITLE
fix: Migrate from undocumented api/v2 to documented v1 endpoints

### DIFF
--- a/src/services/actions.service.spec.ts
+++ b/src/services/actions.service.spec.ts
@@ -269,9 +269,13 @@ describe('ActionsService', () => {
                 Promise.resolve(undefined),
             )
 
+            jest.spyOn(TodoistService.prototype, 'getCompletedInfo').mockImplementation(() =>
+                Promise.resolve([]),
+            )
+
             const getCompletedItems = jest
                 .spyOn(TodoistService.prototype, 'getCompletedTasks')
-                .mockImplementation(() => Promise.resolve({ tasks: [], completedInfo: [] }))
+                .mockImplementation(() => Promise.resolve([]))
 
             await target.export({
                 context: { user: { id: 42 } as DoistCardContextUser, theme: 'light' },
@@ -312,6 +316,11 @@ describe('ActionsService', () => {
                 Promise.resolve({ results: [parentTask], nextCursor: null }),
             )
 
+            // completed_info from sync API tells us parent1 has completed subtasks
+            jest.spyOn(TodoistService.prototype, 'getCompletedInfo').mockImplementation(() =>
+                Promise.resolve([{ item_id: 'parent1', completed_items: 2 }]),
+            )
+
             const completedSubtasks = [
                 {
                     id: 'sub1',
@@ -333,23 +342,12 @@ describe('ActionsService', () => {
                 .spyOn(TodoistService.prototype, 'getCompletedTasks')
                 .mockImplementation(({ projectId, taskId }) => {
                     if (projectId === '1234') {
-                        // Project-level call returns completedInfo indicating
-                        // which tasks have completed subtasks
-                        return Promise.resolve({
-                            tasks: [],
-                            completedInfo: [{ item_id: 'parent1', completed_items: 2 }],
-                        })
+                        return Promise.resolve([])
                     }
                     if (taskId === 'parent1') {
-                        return Promise.resolve({
-                            tasks: completedSubtasks,
-                            completedInfo: [
-                                { item_id: 'sub1', completed_items: 0 },
-                                { item_id: 'sub2', completed_items: 0 },
-                            ],
-                        })
+                        return Promise.resolve(completedSubtasks)
                     }
-                    return Promise.resolve({ tasks: [], completedInfo: [] })
+                    return Promise.resolve([])
                 })
 
             jest.spyOn(target['googleSheetsService'], 'exportToSheets').mockImplementation(() =>
@@ -406,6 +404,11 @@ describe('ActionsService', () => {
                 Promise.resolve({ results: sections, nextCursor: null }),
             )
 
+            // completed_info from sync API tells us section1 has completed tasks
+            jest.spyOn(TodoistService.prototype, 'getCompletedInfo').mockImplementation(() =>
+                Promise.resolve([{ section_id: 'section1', completed_items: 1 }]),
+            )
+
             const completedTask = {
                 id: 'task1',
                 projectId: '1234',
@@ -418,20 +421,12 @@ describe('ActionsService', () => {
                 .spyOn(TodoistService.prototype, 'getCompletedTasks')
                 .mockImplementation(({ projectId, sectionId }) => {
                     if (projectId === '1234') {
-                        // Project-level call returns completedInfo indicating
-                        // which sections have completed tasks
-                        return Promise.resolve({
-                            tasks: [],
-                            completedInfo: [{ section_id: 'section1', completed_items: 1 }],
-                        })
+                        return Promise.resolve([])
                     }
                     if (sectionId === 'section1') {
-                        return Promise.resolve({
-                            tasks: [completedTask],
-                            completedInfo: [{ item_id: 'task1', completed_items: 0 }],
-                        })
+                        return Promise.resolve([completedTask])
                     }
-                    return Promise.resolve({ tasks: [], completedInfo: [] })
+                    return Promise.resolve([])
                 })
 
             jest.spyOn(target['googleSheetsService'], 'exportToSheets').mockImplementation(() =>
@@ -480,6 +475,15 @@ describe('ActionsService', () => {
                 Promise.resolve({ results: [parentTask], nextCursor: null }),
             )
 
+            // completed_info from sync API tells us about the full hierarchy:
+            // parent1 has completed subtasks, and sub1 also has completed subtasks
+            jest.spyOn(TodoistService.prototype, 'getCompletedInfo').mockImplementation(() =>
+                Promise.resolve([
+                    { item_id: 'parent1', completed_items: 2 },
+                    { item_id: 'sub1', completed_items: 1 },
+                ]),
+            )
+
             const completedSubtasks = [
                 {
                     id: 'sub1',
@@ -504,26 +508,15 @@ describe('ActionsService', () => {
                 .spyOn(TodoistService.prototype, 'getCompletedTasks')
                 .mockImplementation(({ projectId, taskId }) => {
                     if (projectId === '1234') {
-                        // Project-level call returns completedInfo indicating
-                        // which tasks have completed subtasks
-                        return Promise.resolve({
-                            tasks: [],
-                            completedInfo: [{ item_id: 'parent1', completed_items: 2 }],
-                        })
+                        return Promise.resolve([])
                     }
                     if (taskId === 'parent1') {
-                        return Promise.resolve({
-                            tasks: completedSubtasks,
-                            completedInfo: [{ item_id: 'sub1', completed_items: 1 }],
-                        })
+                        return Promise.resolve(completedSubtasks)
                     }
                     if (taskId === 'sub1') {
-                        return Promise.resolve({
-                            tasks: completedSubSubtasks,
-                            completedInfo: [],
-                        })
+                        return Promise.resolve(completedSubSubtasks)
                     }
-                    return Promise.resolve({ tasks: [], completedInfo: [] })
+                    return Promise.resolve([])
                 })
 
             jest.spyOn(target['googleSheetsService'], 'exportToSheets').mockImplementation(() =>

--- a/src/services/actions.service.ts
+++ b/src/services/actions.service.ts
@@ -27,7 +27,7 @@ import { getExportOptions } from '../utils/input-helpers'
 
 import { AdaptiveCardService } from './adaptive-card.service'
 import { GoogleSheetsService } from './google-sheets.service'
-import { type CompletedInfo, TodoistService } from './todoist.service'
+import { TodoistService } from './todoist.service'
 import { UserDatabaseService } from './user-database.service'
 
 import type { Section } from '@doist/todoist-api-typescript'
@@ -262,22 +262,23 @@ export class ActionsService extends ActionsServiceBase {
     }): Promise<Task[]> {
         const { appToken, projectId, tasks, sections } = params
 
-        // Fetch completed tasks at the project level first.
-        // The archive/items response includes completed_info, which tells us
-        // which tasks and sections have completed children. This replaces
-        // the previous getCompletedInfo call that used the now-deprecated
-        // v9 sync endpoint.
-        const projectCompletedTasks = await this.fetchCompletedTasksForProjectId(
-            appToken,
+        // Fetch completed_info from the Sync API to determine which tasks
+        // and sections have completed children that need to be fetched.
+        // This uses the documented v1 Sync endpoint.
+        const completedInfo = await this.todoistService.getCompletedInfo({ token: appToken })
+
+        // Fetch completed tasks at the project level
+        const projectCompletedTasks = await this.todoistService.getCompletedTasks({
+            token: appToken,
             projectId,
-        )
+        })
 
         const taskIdsWithCompletedSubtasks = this.findTaskIdsWithCompletedSubtasks(
-            projectCompletedTasks.completedInfo,
+            completedInfo,
             tasks,
         )
         const sectionIdsWithCompletedTasks = this.findSectionIdsWithCompletedTasks(
-            projectCompletedTasks.completedInfo,
+            completedInfo,
             sections,
         )
 
@@ -286,62 +287,42 @@ export class ActionsService extends ActionsServiceBase {
             this.fetchCompletedTasksForSectionIds(appToken, sectionIdsWithCompletedTasks),
         ])
 
-        let allCompletedInfo = [
-            ...projectCompletedTasks.completedInfo,
-            ...taskCompletedTasks.completedInfo,
-            ...sectionCompletedTasks.completedInfo,
-        ]
         let allCompletedTasks = [
-            ...projectCompletedTasks.tasks,
-            ...taskCompletedTasks.tasks,
-            ...sectionCompletedTasks.tasks,
+            ...projectCompletedTasks,
+            ...taskCompletedTasks,
+            ...sectionCompletedTasks,
         ]
 
         let completedTasksIdsWithCompletedSubtasks = this.findTaskIdsWithCompletedSubtasks(
-            allCompletedInfo,
+            completedInfo,
             allCompletedTasks,
         )
 
         // completed tasks can have completed subtasks, so we need to loop
         // until no more completed subtasks are found
         while (completedTasksIdsWithCompletedSubtasks.size > 0) {
-            const subtaskResult = await this.fetchCompletedTasksForTaskIds(
+            const subtaskResults = await this.fetchCompletedTasksForTaskIds(
                 appToken,
                 completedTasksIdsWithCompletedSubtasks,
             )
 
-            allCompletedTasks = [...allCompletedTasks, ...subtaskResult.tasks]
-            allCompletedInfo = [...allCompletedInfo, ...subtaskResult.completedInfo]
+            allCompletedTasks = [...allCompletedTasks, ...subtaskResults]
 
             completedTasksIdsWithCompletedSubtasks = this.findTaskIdsWithCompletedSubtasks(
-                allCompletedInfo,
-                subtaskResult.tasks,
+                completedInfo,
+                subtaskResults,
             )
         }
 
         return allCompletedTasks
     }
 
-    private async fetchCompletedTasksForProjectId(
-        appToken: string,
-        projectId: string,
-    ): Promise<{ tasks: Task[]; completedInfo: CompletedInfo[] }> {
-        try {
-            return await this.todoistService.getCompletedTasks({
-                token: appToken,
-                projectId,
-            })
-        } catch (error: unknown) {
-            return { tasks: [], completedInfo: [] }
-        }
-    }
-
     private async fetchCompletedTasksForTaskIds(
         appToken: string,
         taskIds: Set<string>,
-    ): Promise<{ tasks: Task[]; completedInfo: CompletedInfo[] }> {
+    ): Promise<Task[]> {
         if (taskIds.size === 0) {
-            return { tasks: [], completedInfo: [] }
+            return []
         }
 
         // Use batched execution to limit concurrent API calls to 10 at a time
@@ -356,18 +337,15 @@ export class ActionsService extends ActionsServiceBase {
             10, // Max 10 concurrent requests
         )
 
-        const tasks = results.flatMap((result) => result.tasks)
-        const completedInfo = results.flatMap((result) => result.completedInfo)
-
-        return { tasks, completedInfo }
+        return results.flat()
     }
 
     private async fetchCompletedTasksForSectionIds(
         appToken: string,
         sectionIds: Set<string>,
-    ): Promise<{ tasks: Task[]; completedInfo: CompletedInfo[] }> {
+    ): Promise<Task[]> {
         if (sectionIds.size === 0) {
-            return { tasks: [], completedInfo: [] }
+            return []
         }
 
         // Use batched execution to limit concurrent API calls to 10 at a time
@@ -382,22 +360,19 @@ export class ActionsService extends ActionsServiceBase {
             10, // Max 10 concurrent requests
         )
 
-        const tasks = results.flatMap((result) => result.tasks)
-        const completedInfo = results.flatMap((result) => result.completedInfo)
-
-        return { tasks, completedInfo }
+        return results.flat()
     }
 
     private findTaskIdsWithCompletedSubtasks(
-        completedInfo: CompletedInfo[],
+        completedInfo: { item_id?: string; completed_items: number }[],
         tasks: Task[],
     ): Set<string> {
         const taskIds = new Set<string>()
-        const activeTaskIds = new Set(tasks.map((task) => task.id))
+        const taskIdSet = new Set(tasks.map((task) => task.id))
 
-        // Find tasks that have completed subtasks and are in our active tasks list
+        // Find tasks that have completed subtasks and are in our tasks list
         completedInfo.forEach((info) => {
-            if (info.item_id && activeTaskIds.has(info.item_id)) {
+            if (info.item_id && taskIdSet.has(info.item_id) && info.completed_items > 0) {
                 taskIds.add(info.item_id)
             }
         })
@@ -406,7 +381,7 @@ export class ActionsService extends ActionsServiceBase {
     }
 
     private findSectionIdsWithCompletedTasks(
-        completedInfo: CompletedInfo[],
+        completedInfo: { section_id?: string; completed_items: number }[],
         sections: Section[],
     ): Set<string> {
         const sectionIds = new Set<string>()
@@ -414,7 +389,11 @@ export class ActionsService extends ActionsServiceBase {
 
         // Find sections that have completed tasks and are in our active sections list
         completedInfo.forEach((info) => {
-            if (info.section_id && activeSectionIds.has(info.section_id)) {
+            if (
+                info.section_id &&
+                activeSectionIds.has(info.section_id) &&
+                info.completed_items > 0
+            ) {
                 sectionIds.add(info.section_id)
             }
         })

--- a/src/services/todoist.service.spec.ts
+++ b/src/services/todoist.service.spec.ts
@@ -24,39 +24,82 @@ describe('TodoistService', () => {
         expect(target).toBeDefined()
     })
 
-    it('should call for completed tasks', async () => {
-        setupGetCompletedItems([])
-        const target = await getTarget()
-        const httpServer = jest.spyOn(target['httpService'], 'get')
+    describe('getCompletedTasks', () => {
+        it('should call for completed tasks', async () => {
+            setupGetCompletedItems([])
+            const target = await getTarget()
+            const httpServer = jest.spyOn(target['httpService'], 'get')
 
-        const result = await target.getCompletedTasks({
-            projectId: '123',
-            token: 'kwijibo',
+            const result = await target.getCompletedTasks({
+                projectId: '123',
+                token: 'kwijibo',
+            })
+            expect(result).toEqual([])
+            expect(httpServer).toHaveBeenCalledTimes(1)
         })
-        expect(result).toEqual({ tasks: [], completedInfo: [] })
-        expect(httpServer).toHaveBeenCalledTimes(1)
+
+        test.each([
+            [0, 1],
+            [50, 1],
+            [99, 1],
+            [100, 1],
+            [101, 2],
+            [150, 2],
+            [199, 2],
+            [200, 2],
+            [201, 3],
+        ])('when task count is %i, should call %i times', async (taskCount, expectedCalls) => {
+            setupGetCompletedItems(Array(taskCount).fill({}) as SyncTask[])
+            const target = await getTarget()
+            const httpServer = jest.spyOn(target['httpService'], 'get')
+
+            await target.getCompletedTasks({
+                projectId: '123',
+                token: 'kwijibo',
+            })
+            expect(httpServer).toHaveBeenCalledTimes(expectedCalls)
+        })
     })
 
-    test.each([
-        [0, 1],
-        [50, 1],
-        [99, 1],
-        [100, 1],
-        [101, 2],
-        [150, 2],
-        [199, 2],
-        [200, 2],
-        [201, 3],
-    ])('when task count is %i, should call %i times', async (taskCount, expectedCalls) => {
-        setupGetCompletedItems(Array(taskCount).fill({}) as SyncTask[])
-        const target = await getTarget()
-        const httpServer = jest.spyOn(target['httpService'], 'get')
+    describe('getCompletedInfo', () => {
+        it('should fetch completed_info from the v1 sync endpoint', async () => {
+            const completedInfo = [
+                { project_id: '123', completed_items: 5 },
+                { item_id: 'task1', completed_items: 2 },
+            ]
 
-        await target.getCompletedTasks({
-            projectId: '123',
-            token: 'kwijibo',
+            let capturedBody: Record<string, string> | undefined
+            let capturedAuthHeader: string | undefined
+
+            server.use(
+                rest.post('https://api.todoist.com/api/v1/sync', async (req, res, ctx) => {
+                    capturedBody = await req.json()
+                    capturedAuthHeader = req.headers.get('Authorization') ?? undefined
+                    return res(ctx.json({ completed_info: completedInfo }))
+                }),
+            )
+
+            const target = await getTarget()
+            const result = await target.getCompletedInfo({ token: 'kwijibo' })
+            expect(result).toEqual(completedInfo)
+            expect(capturedAuthHeader).toBe('Bearer kwijibo')
+            expect(capturedBody).toEqual({
+                sync_token: '*',
+                resource_types: '["completed_info"]',
+            })
         })
-        expect(httpServer).toHaveBeenCalledTimes(expectedCalls)
+
+        it('should return an empty array when the sync endpoint fails', async () => {
+            server.use(
+                rest.post('https://api.todoist.com/api/v1/sync', (_req, res, ctx) => {
+                    return res(ctx.status(500))
+                }),
+            )
+
+            const target = await getTarget()
+            const result = await target.getCompletedInfo({ token: 'kwijibo' })
+            expect(result).toEqual([])
+        })
     })
 
     function setupGetCompletedItems(items: SyncTask[]) {
@@ -64,23 +107,24 @@ describe('TodoistService', () => {
         const totalPages = allTasks.length
 
         server.use(
-            rest.get('https://api.todoist.com/api/v2/archive/items', (req, res, ctx) => {
-                const cursor = req.url.searchParams.get('cursor')
-                const pageIndex = cursor ? parseInt(cursor, 10) : 0
-                const tasks = allTasks[pageIndex] ?? []
-                const hasMore = pageIndex < totalPages - 1
-                const nextCursor = hasMore ? (pageIndex + 1).toString() : null
+            rest.get(
+                'https://api.todoist.com/api/v1/tasks/completed/by_completion_date',
+                (req, res, ctx) => {
+                    const cursor = req.url.searchParams.get('cursor')
+                    const pageIndex = cursor ? parseInt(cursor, 10) : 0
+                    const tasks = allTasks[pageIndex] ?? []
+                    const hasMore = pageIndex < totalPages - 1
+                    const nextCursor = hasMore ? (pageIndex + 1).toString() : null
 
-                return res(
-                    ctx.json({
-                        total: items.length,
-                        completed_info: [],
-                        has_more: hasMore,
-                        next_cursor: nextCursor,
-                        items: tasks,
-                    }),
-                )
-            }),
+                    return res(
+                        ctx.json({
+                            has_more: hasMore,
+                            next_cursor: nextCursor,
+                            items: tasks,
+                        }),
+                    )
+                },
+            ),
         )
     }
 

--- a/src/services/todoist.service.ts
+++ b/src/services/todoist.service.ts
@@ -8,6 +8,13 @@ import type { Task } from '../types'
 
 const LIMIT = 100
 
+/**
+ * A date predating Todoist's existence (founded 2007), used as the `since`
+ * parameter when fetching completed tasks from the v1 API to ensure all
+ * historical completed tasks are included.
+ */
+const COMPLETED_TASKS_SINCE = '2006-01-01T00:00:00Z'
+
 type SyncDue = {
     date: string
     is_recurring: boolean
@@ -51,8 +58,6 @@ export type CompletedInfo = {
 }
 
 type CompletedTasksResponse = {
-    total: number
-    completed_info: CompletedInfo[]
     has_more: boolean
     next_cursor: string | null
     items: SyncTask[]
@@ -123,24 +128,56 @@ export class TodoistService {
         projectId?: string
         taskId?: string
         sectionId?: string
-    }): Promise<{ tasks: Task[]; completedInfo: CompletedInfo[] }> {
+    }): Promise<Task[]> {
         try {
-            const result = await this.getCompletedTasksInternal({
+            const items = await this.getCompletedTasksInternal({
                 token,
                 projectId,
                 taskId,
                 sectionId,
             })
 
-            return {
-                tasks: result.items.map((task) => this.getTaskFromQuickAddResponse(task)),
-                completedInfo: result.completedInfo,
-            }
+            return items.map((task) => this.getTaskFromQuickAddResponse(task))
         } catch (error: unknown) {
-            return { tasks: [], completedInfo: [] }
+            return []
         }
     }
 
+    /**
+     * Fetches completed_info from the Todoist Sync API (v1).
+     *
+     * completed_info indicates the number of completed items within each
+     * active project, section, or parent item. This is used to determine
+     * which tasks and sections have completed children that need to be
+     * fetched separately.
+     *
+     * @see https://developer.todoist.com/api/v1/#tag/Sync/Overview/Read-resources
+     */
+    async getCompletedInfo({ token }: { token: string }): Promise<CompletedInfo[]> {
+        try {
+            const response = await lastValueFrom(
+                this.httpService.post<{ completed_info: CompletedInfo[] }>(
+                    'https://api.todoist.com/api/v1/sync',
+                    { sync_token: '*', resource_types: '["completed_info"]' },
+                    { headers: { Authorization: `Bearer ${token}` } },
+                ),
+            )
+
+            return response.data.completed_info
+        } catch (error: unknown) {
+            return []
+        }
+    }
+
+    /**
+     * Fetches completed tasks using the documented Todoist API v1 endpoint.
+     *
+     * Uses a wide date range (since 2006) to fetch all completed tasks,
+     * effectively replicating the behavior of the previous undocumented
+     * archive/items endpoint.
+     *
+     * @see https://developer.todoist.com/api/v1/#tag/Tasks/operation/getTasks_Completed_By_Completion_Date
+     */
     private async getCompletedTasksInternal({
         projectId,
         token,
@@ -151,24 +188,25 @@ export class TodoistService {
         projectId?: string
         taskId?: string
         sectionId?: string
-    }): Promise<{ items: SyncTask[]; completedInfo: CompletedInfo[] }> {
+    }): Promise<SyncTask[]> {
         const allItems: SyncTask[] = []
-        const allCompletedInfo: CompletedInfo[] = []
+        const until = new Date().toISOString()
 
         const fetchPage = async (
             cursor?: string | null,
         ): Promise<{
             results: SyncTask[]
             nextCursor: string | null
-            completedInfo: CompletedInfo[]
         }> => {
             const response = await lastValueFrom(
                 this.httpService.get<CompletedTasksResponse>(
-                    'https://api.todoist.com/api/v2/archive/items',
+                    'https://api.todoist.com/api/v1/tasks/completed/by_completion_date',
                     {
                         headers: { Authorization: `Bearer ${token}` },
                         params: {
                             limit: LIMIT,
+                            since: COMPLETED_TASKS_SINCE,
+                            until,
                             ...(projectId ? { project_id: projectId } : {}),
                             ...(taskId ? { parent_id: taskId } : {}),
                             ...(sectionId ? { section_id: sectionId } : {}),
@@ -181,28 +219,21 @@ export class TodoistService {
             return {
                 results: response.data.items,
                 nextCursor: response.data.has_more ? response.data.next_cursor : null,
-                completedInfo: response.data.completed_info,
             }
         }
 
         let nextCursor: string | null | undefined = undefined
 
         do {
-            const pageResult: {
-                results: SyncTask[]
-                nextCursor: string | null
-                completedInfo: CompletedInfo[]
-            } = await fetchPage(nextCursor)
+            const pageResult: { results: SyncTask[]; nextCursor: string | null } = await fetchPage(
+                nextCursor,
+            )
 
             allItems.push(...pageResult.results)
-            allCompletedInfo.push(...pageResult.completedInfo)
             nextCursor = pageResult.nextCursor
         } while (nextCursor !== null)
 
-        return {
-            items: allItems,
-            completedInfo: allCompletedInfo,
-        }
+        return allItems
     }
 
     private getTaskFromQuickAddResponse(responseData: SyncTask): Task {

--- a/test/e2e/export.e2e-spec.ts
+++ b/test/e2e/export.e2e-spec.ts
@@ -36,10 +36,8 @@ describe('export e2e tests', () => {
             results: [],
             nextCursor: null,
         })
-        jest.spyOn(TodoistService.prototype, 'getCompletedTasks').mockResolvedValue({
-            tasks: [],
-            completedInfo: [],
-        })
+        jest.spyOn(TodoistService.prototype, 'getCompletedTasks').mockResolvedValue([])
+        jest.spyOn(TodoistService.prototype, 'getCompletedInfo').mockResolvedValue([])
     })
 
     beforeAll(async () => {


### PR DESCRIPTION
## Summary

Follow-up to #270 addressing [Scott's review feedback](https://github.com/Doist/todoist-google-sheets/pull/270#discussion_r2796008384) about the use of the undocumented `api/v2/archive/items` endpoint.

- **Completed tasks**: Migrated from undocumented `api/v2/archive/items` to the [documented `api/v1/tasks/completed/by_completion_date`](https://developer.todoist.com/api/v1/#tag/Tasks/operation/getTasks_Completed_By_Completion_Date) endpoint, adding the required `since`/`until` date range parameters
- **Completed info**: Restored `getCompletedInfo()` using the [documented v1 Sync endpoint](https://developer.todoist.com/api/v1/#tag/Sync/Overview/Read-resources) (`api/v1/sync` with `resource_types: ["completed_info"]`), replacing the undocumented `completed_info` field that was bundled in the `archive/items` response
- **Simplified return types**: `getCompletedTasks()` now returns `Task[]` instead of `{ tasks, completedInfo }` since the two concerns are fetched from separate endpoints

## Test plan

- [x] All 63 tests pass (unit + e2e), including new error-path test for `getCompletedInfo`
- [ ] Manually verify completed tasks export works end-to-end
- [ ] Verify the v1 endpoint response format matches expectations (field names, pagination)